### PR TITLE
カスタマイズ Cloud Build Notifier 

### DIFF
--- a/README-2022-10.md
+++ b/README-2022-10.md
@@ -1,0 +1,96 @@
+# Cloud Build Notifiers
+
+This repo provides deployable notifier images and sources, as well as libraries
+for creating new notifiers.
+
+[Cloud Build](https://cloud.google.com/cloud-build) notifiers are Docker
+containers that connect to the
+[Cloud Build Pub/Sub topic](https://cloud.google.com/cloud-build/docs/send-build-notifications)
+that adapt Pub/Sub messages about Build update notifications to other
+services/protocols, such as SMTP for email.
+Cloud Build notifiers are long-lived binaries that receive notifications throughout
+Builds' lifecycles (e.g. from the Build starting to execute through the Build finishing).
+
+All notifiers can be built by Cloud Build and deployed on
+[Cloud Run](https://cloud.google.com/run). The only prerequisite is to be a
+Cloud Build user and to have the
+[gcloud CLI tool](https://cloud.google.com/sdk/gcloud/) installed and configured
+for your Cloud Build project(s).
+
+There are currently 3 supported notifier types:
+
+-   [`bigquery`](./bigquery/README.md), which writes Build updates and related
+    data to a BigQuery table.
+-   [`http`](./http/README.md), which sends (HTTP `POST`s) a JSON payload to
+    another HTTP endpoint.
+-   [`slack`](./slack/README.md), which uses a Slack webhook to post a message
+    in a Slack channel.
+-   [`smtp`](./smtp/README.md), which sends emails via an SMTP server.
+
+**See the official documentation on Google Cloud for how to configure each notifier:**
+
+- [Configuring BigQuery notifications](https://cloud.google.com/cloud-build/docs/configuring-notifications/configure-bigquery)
+- [Configuring HTTP notifications](https://cloud.google.com/cloud-build/docs/configuring-notifications/configure-http)
+- [Configuring Slack notifications](https://cloud.google.com/cloud-build/docs/configuring-notifications/configure-slack)
+- [Configuring SMTP notifications](https://cloud.google.com/cloud-build/docs/configuring-notifications/configure-smtp)
+
+
+## Setup Script
+
+A [setup script](./setup.sh) exists that should automate _most_ of the notifier setup.
+
+Run `./setup.sh --help` for usage instructions.
+
+## Common Flags
+
+The following are flags that belong to every notifier via inclusion of the `lib/notifiers` library.
+
+### `--smoketest`
+
+This flag starts up the notifier image but only logs the notifier name (via type) and then exits.
+
+### `--setup_check`
+
+This flag starts up the notifier, which does the following:
+
+1. Read the notifier configuration YAML from STDIN.
+1. Decode it into a configuration object.
+1. Attempt to call `notifier.SetUp` on the given notifier using the configuration and a faked-out `SecretGetter`.
+1. Exit successfully unless one of the previous steps failed.
+
+This can be done using the following commands:
+
+```bash
+# First build the notifier locally.
+$ sudo docker build . \
+    -f=./${NOTIFIER_TYPE}/Dockerfile --tag=${NOTIFIER_TYPE}-test
+# Then run the `setup_check` with your YAML.
+# --interactive to allow reading from STDIN.
+# --rm to clean/remove the image once it exits.
+$ sudo docker run \
+    --interactive \
+    --rm \ 
+    --name=${NOTIFIER_TYPE}-test \
+    ${NOTIFIER_TYPE}-test:latest --setup_check --alsologtostderr -v=5 \
+    < path/to/my/config.yaml 
+```
+
+## License
+
+This project uses an [Apache 2.0 license](./LICENSE).
+
+## Contributing
+
+See [here](./CONTRIBUTING.md) for contributing guidelines.
+
+## Support
+
+There are several ways to get support for issues in this project:
+
+-   [Cloud Build Slack channel](https://googlecloud-community.slack.com/archives/C4KCRJL4D)
+-   [Cloud Build Issue Tracker](https://issuetracker.google.com/issues/new?component=190802&template=1162743)
+-   [General Google Cloud support](https://cloud.google.com/cloud-build/docs/getting-support)
+
+Note: Issues filed in this repo are not guaranteed to be addressed.
+We recommend filing issues via the [Issue Tracker](https://issuetracker.google.com/issues/new?component=190802&template=1162743).
+

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ There are two the principal axis branches.
 ### Preparation
 Set `gcloud config`
 
-### Check vds-amc-client configuration is set on your local.
+### Check vds-client-amc configuration is set on your local.
 - Execute following command to check it
   ```
   % gcloud config configurations list
@@ -54,12 +54,12 @@ Set `gcloud config`
   .
   ```
 
-- If you already have the config, switch config to vds-amc-client
+- If you already have the config, switch config to vds-client-amc
   ```
   % gcloud config configurations activate ana-op
   ```
 
-- If not set vds-amc-client configuration on local, execute following command.
+- If not set vds-client-amc configuration on local, execute following command.
   ```
   % gcloud config configurations create ana-op       // create configuration
   % gcloud config set compute/region asia-northeast1 // set regison

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ There are two the principal axis branches.
     - Trriger (used cloud build trigger)
 
 
-## How to build and push slack image and deploy to Cloud Run
+## How to build, push slack image and deploy to Cloud Run
 
 ### Preparation
 Set `gcloud config`
@@ -61,11 +61,23 @@ Set `gcloud config`
 
 - If not set vds-amc-client configuration on local, execute following command.
   ```
-  % gcloud config configurations create ana-op  // create configuration
+  % gcloud config configurations create ana-op       // create configuration
   % gcloud config set compute/region asia-northeast1 // set regison
-  % gcloud config set compute/zone asia-northeast1-a
-  % gcloud config set core/account YOUR_EMAIL
-  % gcloud config set core/project vds-client-amc
+  % gcloud config set compute/zone asia-northeast1-a // set zone
+  % gcloud config set core/project vds-client-amc    // set project id
+  ```
+
+### How to build, push slack image and deploy to Cloud Build
+- A makefile exists 
+  ```
+  % cd [this project root]
+  % make all
+  ```
+
+- When get message on your terminal, it is successfully deployed to Cloud run.
+  ```
+  Service [slack-notifier] revision [slack-notifier-00070-lug] has been deployed and is serving 100 percent of traffic.
+  Service URL: https://slack-notifier-qtswhpgk2a-an.a.run.app
   ```
 
 

--- a/makefile
+++ b/makefile
@@ -1,0 +1,27 @@
+REPO_NAME=asia.gcr.io/vds-client-amc
+IMG_NAME=notifier
+IMG_TAG=latest
+BACKET_NAME=vds-client-amc-notifiers-config
+PROJECT_ID=vds-client-amc
+
+all: build push apply deploy
+
+build:
+	@echo "Building docker image..."
+	@docker build . -t ${REPO_NAME}/${IMG_NAME}:${IMG_TAG} --platform linux/amd64 -f ./slack/Dockerfile
+
+push:
+	@echo "Pushing docker image..."
+	@docker push ${REPO_NAME}/${IMG_NAME}:${IMG_TAG}
+
+apply:
+	@echo "Applying Configfile to Cloud Storage..."
+	@gsutil cp ./slack/slack.yaml gs://${BACKET_NAME}/slack.yaml
+
+deploy:
+	@echo "Deploying to Cloud Run..."
+	@gcloud run deploy slack-notifier \
+		--image=${REPO_NAME}/${IMG_NAME}:${IMG_TAG} \
+		--no-allow-unauthenticated \
+		--max-instances=1 \
+		--update-env-vars=CONFIG_PATH=gs://${BACKET_NAME}/slack.yaml,PROJECT_ID=${PROJECT_ID}

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 REPO_NAME=asia.gcr.io/vds-client-amc
 IMG_NAME=notifier
 IMG_TAG=latest
-BACKET_NAME=vds-client-amc-notifiers-config
+BUCKET_NAME=vds-client-amc-notifiers-config
 PROJECT_ID=vds-client-amc
 
 all: build push apply deploy

--- a/slack/main_test.go
+++ b/slack/main_test.go
@@ -13,8 +13,23 @@ func TestWriteMessage(t *testing.T) {
 	b := &cbpb.Build{
 		ProjectId: "my-project-id",
 		Id:        "some-build-id",
-		Status:    cbpb.Build_SUCCESS,
-		LogUrl:    "https://some.example.com/log/url?foo=bar",
+		Substitutions: map[string]string{
+			"BRANCH_NAME":               "test-deploy",
+			"COMMIT_SHA":                "commit-test-test",
+			"REF_NAME":                  "test-deploy",
+			"REPO_NAME":                 "test-repository",
+			"REVISION_ID":               "test-revison",
+			"SHORT_SHA":                 "test",
+			"TRIGGER_BUILD_CONFIG_PATH": "cloudbuild/cloudbuild.yaml",
+			"TRIGGER_NAME":              "triggername",
+			"_CLUSTER_NAME":             "sample-cluster",
+			"_ENV":                      "sample",
+			"_FRONT_DEPLOYMENT_YAML":    "sample.yaml",
+			"_REGION":                   "asia-northeast1",
+			"_ZONE":                     "asia-northeast1-a",
+		},
+		Status: cbpb.Build_SUCCESS,
+		LogUrl: "https://some.example.com/log/url?foo=bar",
 	}
 
 	got, err := n.writeMessage(b)
@@ -24,10 +39,15 @@ func TestWriteMessage(t *testing.T) {
 
 	want := &slack.WebhookMessage{
 		Attachments: []slack.Attachment{{
-			Text:  "Cloud Build (my-project-id, some-build-id): SUCCESS",
+			Text: `Successfully deployed to sample environment!! 
+			 - Environment : sample
+			 - Branch : test-deploy
+			 - Deployed Commit : commit-test-test
+			 - Cluster : sample-cluster
+			 - Trriger : triggername`,
 			Color: "good",
 			Actions: []slack.AttachmentAction{{
-				Text: "View Logs",
+				Text: "Open Build Details",
 				Type: "button",
 				URL:  "https://some.example.com/log/url?foo=bar&utm_campaign=google-cloud-build-notifiers&utm_medium=chat&utm_source=google-cloud-build",
 			}},

--- a/slack/slack.yaml
+++ b/slack/slack.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: cloud-build-notifiers/v1
+kind: SlackNotifier
+metadata:
+  name: cloudbuild-slack-notifier
+spec:
+  notification:
+    filter: build.status in [Build.Status.SUCCESS, Build.Status.FAILURE, Build.Status.CANCELLED, Build.Status.TIMEOUT]
+    delivery:
+      webhookUrl:
+        secretRef: webhook-url
+  secrets:
+  - name: webhook-url
+    value: projects/vds-client-amc/secrets/deploy-slack-notification/versions/latest


### PR DESCRIPTION
# Ticket
- https://veltra-tech.atlassian.net/browse/B2BPJ-288

# Overview
- [このRepositoryができた背景](https://veltra-tech.atlassian.net/browse/B2BPJ-288)
- [GoogleCloudPlatform/cloud-build-notifiers](https://github.com/GoogleCloudPlatform/cloud-build-notifiers)の最新のsource codeだとslack通知が安定しないので、 1つversionを落としたものをカスタマイズ

# What I did
- `amc-master` branchを作成
  - [GoogleCloudPlatform/cloud-build-notifiers](https://github.com/GoogleCloudPlatform/cloud-build-notifiers)より、[slack-1.14.0](https://github.com/GoogleCloudPlatform/cloud-build-notifiers/tree/slack-1.14.0)へcheckoutしたbranch
  - 最新版（`master`）だと安定しないので`slack-1.14.0`まで戻った`amc-master` からfeature branchを分岐させました
     
- ANAOP用のREADMEを作成（defaultのREADMEは[README-2022-10.md](https://github.com/veltra/cloud-build-notifiers/blob/feature/B2BPJ-288/README-2022-10.md)にRename）
- 設定ファイル `./slack/slack.yaml` を更新
- makeコマンドで、Cloud Runへデプロイできるようにmakefileを作成
  - 作成したmakefileでやっていること
    - docker image build ~ push
    - Cloud Storageへ設定ファイル`./slack/slack.yaml`をUL
    - Cloud RunへDeploy
- buildされたimageは[asia.gcr.io/vds-client-amc/notifier](https://console.cloud.google.com/gcr/images/vds-client-amc/asia/notifier?project=vds-client-amc) で管理
- Slack通知内容を修正するために`main.go`を修正




