### PR TITLE
Triggerがキャンセルされた時の文言を修正

### DIFF
--- a/makefile
+++ b/makefile
@@ -16,7 +16,7 @@ push:
 
 apply:
 	@echo "Applying Configfile to Cloud Storage..."
-	@gsutil cp ./slack/slack.yaml gs://${BACKET_NAME}/slack.yaml
+	@gsutil cp ./slack/slack.yaml gs://${BUCKET_NAME}/slack.yaml
 
 deploy:
 	@echo "Deploying to Cloud Run..."
@@ -24,4 +24,4 @@ deploy:
 		--image=${REPO_NAME}/${IMG_NAME}:${IMG_TAG} \
 		--no-allow-unauthenticated \
 		--max-instances=1 \
-		--update-env-vars=CONFIG_PATH=gs://${BACKET_NAME}/slack.yaml,PROJECT_ID=${PROJECT_ID}
+		--update-env-vars=CONFIG_PATH=gs://${BUCKET_NAME}/slack.yaml,PROJECT_ID=${PROJECT_ID}

--- a/slack/main.go
+++ b/slack/main.go
@@ -108,46 +108,59 @@ func (s *slackNotifier) writeMessage(build *cbpb.Build) (*slack.WebhookMessage, 
 	}
 
 	var txtTemplate string
-	if build.Status == cbpb.Build_SUCCESS {
-		txtTemplate = fmt.Sprintf(
-			`Successfully deployed to %s environment!! 
-			 - Environment : %s
-			 - Branch : %s
-			 - Deployed Commit : %s
-			 - Cluster : %s
-			 - Trriger : %s`,
-			envName,
-			envName,
-			branch,
-			lastCommit,
-			clusterName,
-			triggerName,
-		)
-	} else {
-		txtTemplate = fmt.Sprintf(
-			`Failed deploy to %s environment 
-			 - Environment : %s
-			 - Branch : %s
-			 - Deployed Commit : %s
-			 - Cluster : %s
-			 - Trriger : %s`,
-			envName,
-			envName,
-			branch,
-			lastCommit,
-			clusterName,
-			triggerName,
-		)
-	}
-
 	var clr string
 	switch build.Status {
 	case cbpb.Build_SUCCESS:
 		clr = "good"
+		txtTemplate = fmt.Sprintf(
+			`Successfully deployed to %s environment!! 
+			- Environment : %s
+			- Branch : %s
+			- Deployed Commit : %s
+			- Cluster : %s
+			- Trriger : %s`,
+			envName,
+			envName,
+			branch,
+			lastCommit,
+			clusterName,
+			triggerName,
+		)
+		break
 	case cbpb.Build_FAILURE, cbpb.Build_INTERNAL_ERROR, cbpb.Build_TIMEOUT:
 		clr = "danger"
+		txtTemplate = fmt.Sprintf(
+			`Failed deploy to %s environment 
+			- Environment : %s
+			- Branch : %s
+			- Deployed Commit : %s
+			- Cluster : %s
+			- Trriger : %s`,
+			envName,
+			envName,
+			branch,
+			lastCommit,
+			clusterName,
+			triggerName,
+		)
+		break
 	default:
 		clr = "warning"
+		txtTemplate = fmt.Sprintf(
+			`Stop to deploy to %s environment
+			- Environment : %s
+			- Branch : %s
+			- Deployed Commit : %s
+			- Cluster : %s
+			- Trriger : %s`,
+			envName,
+			envName,
+			branch,
+			lastCommit,
+			clusterName,
+			triggerName,
+		)
+		break
 	}
 
 	logURL, err := notifiers.AddUTMParams(build.LogUrl, notifiers.ChatMedium)

--- a/slack/main_test.go
+++ b/slack/main_test.go
@@ -40,11 +40,11 @@ func TestWriteMessage(t *testing.T) {
 	want := &slack.WebhookMessage{
 		Attachments: []slack.Attachment{{
 			Text: `Successfully deployed to sample environment!! 
-			 - Environment : sample
-			 - Branch : test-deploy
-			 - Deployed Commit : commit-test-test
-			 - Cluster : sample-cluster
-			 - Trriger : triggername`,
+			- Environment : sample
+			- Branch : test-deploy
+			- Deployed Commit : commit-test-test
+			- Cluster : sample-cluster
+			- Trriger : triggername`,
 			Color: "good",
 			Actions: []slack.AttachmentAction{{
 				Text: "Open Build Details",


### PR DESCRIPTION
# What I did
- makefiileの変数修正漏れを直しました。
- TriggerをCloud Buildからキャンセルした時に、Slackに通知される文言を修正。

  - Before
    - ![スクリーンショット 2022-11-07 11 02 33](https://user-images.githubusercontent.com/108470780/200211632-02c96246-153c-44c3-bf47-386e2f3d4a86.png)
    - `Failed deploy to dev environment`

  - After
    - ![スクリーンショット 2022-11-07 11 03 06](https://user-images.githubusercontent.com/108470780/200211678-5988e6b2-9af3-49c8-88d1-c68f63e6ce24.png)
    - `Stop to deploy to dev environment`

